### PR TITLE
Migrate to latest container

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
   <name>${project.groupId}:${project.artifactId}</name>
   <packaging>pom</packaging>
 
-  <version>1.5.3-SNAPSHOT</version>
+  <version>1.6-SNAPSHOT</version>
 
   <url>https://github.com/sonatype/sisu-siesta</url>
 
@@ -79,9 +79,9 @@
       </dependency>
 
       <dependency>
-        <groupId>org.sonatype.sisu</groupId>
-        <artifactId>sisu-inject-bean</artifactId>
-        <version>2.3.4</version>
+        <groupId>org.eclipse.sisu</groupId>
+        <artifactId>org.eclipse.sisu.inject</artifactId>
+        <version>0.1.1</version>
       </dependency>
 
       <dependency>
@@ -183,15 +183,20 @@
       </dependency>
 
       <dependency>
+        <groupId>org.sonatype.sisu</groupId>
+        <artifactId>sisu-guice</artifactId>
+        <version>3.1.8</version>
+      </dependency>
+      <dependency>
         <groupId>org.sonatype.sisu.inject</groupId>
         <artifactId>guice-servlet</artifactId>
-        <version>3.1.4</version>
+        <version>3.1.8</version>
       </dependency>
 
       <dependency>
         <groupId>org.sonatype.sisu.litmus</groupId>
         <artifactId>litmus-testsupport</artifactId>
-        <version>1.6</version>
+        <version>1.8-SNAPSHOT</version>
       </dependency>
 
       <dependency>
@@ -214,31 +219,31 @@
       <dependency>
         <groupId>org.sonatype.sisu.siesta</groupId>
         <artifactId>siesta-common</artifactId>
-        <version>1.5.3-SNAPSHOT</version>
+        <version>1.6-SNAPSHOT</version>
       </dependency>
 
       <dependency>
         <groupId>org.sonatype.sisu.siesta</groupId>
         <artifactId>siesta-xstream</artifactId>
-        <version>1.5.3-SNAPSHOT</version>
+        <version>1.6-SNAPSHOT</version>
       </dependency>
 
       <dependency>
         <groupId>org.sonatype.sisu.siesta</groupId>
         <artifactId>siesta-jackson</artifactId>
-        <version>1.5.3-SNAPSHOT</version>
+        <version>1.6-SNAPSHOT</version>
       </dependency>
 
       <dependency>
         <groupId>org.sonatype.sisu.siesta</groupId>
         <artifactId>siesta-server</artifactId>
-        <version>1.5.3-SNAPSHOT</version>
+        <version>1.6-SNAPSHOT</version>
       </dependency>
 
       <dependency>
         <groupId>org.sonatype.sisu.siesta</groupId>
         <artifactId>siesta-client</artifactId>
-        <version>1.5.3-SNAPSHOT</version>
+        <version>1.6-SNAPSHOT</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -313,8 +318,10 @@
                 <bannedDependencies>
                   <searchTransitive>true</searchTransitive>
                   <excludes>
-                    <!-- Keep junit out, use junit-dep instead -->
-                    <exclude>junit:junit</exclude>
+                    <!-- Keep old junits out -->
+                    <exclude>junit:junit:(,4.10]</exclude>
+                    <exclude>junit:junit-dep</exclude>
+
                     <!-- Keep all JCL out, use jcl-over-slf4j instead -->
                     <exclude>commons-logging:commons-logging</exclude>
                     <exclude>commons-logging:commons-logging-api</exclude>

--- a/siesta-client/pom.xml
+++ b/siesta-client/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.sonatype.sisu.siesta</groupId>
     <artifactId>siesta</artifactId>
-    <version>1.5.3-SNAPSHOT</version>
+    <version>1.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>siesta-client</artifactId>

--- a/siesta-common/pom.xml
+++ b/siesta-common/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.sonatype.sisu.siesta</groupId>
     <artifactId>siesta</artifactId>
-    <version>1.5.3-SNAPSHOT</version>
+    <version>1.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>siesta-common</artifactId>

--- a/siesta-jackson/pom.xml
+++ b/siesta-jackson/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.sonatype.sisu.siesta</groupId>
     <artifactId>siesta</artifactId>
-    <version>1.5.3-SNAPSHOT</version>
+    <version>1.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>siesta-jackson</artifactId>
@@ -38,7 +38,7 @@
 
     <dependency>
       <groupId>org.sonatype.sisu</groupId>
-      <artifactId>sisu-inject-bean</artifactId>
+      <artifactId>sisu-guice</artifactId>
       <optional>true</optional>
     </dependency>
 

--- a/siesta-server/pom.xml
+++ b/siesta-server/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.sonatype.sisu.siesta</groupId>
     <artifactId>siesta</artifactId>
-    <version>1.5.3-SNAPSHOT</version>
+    <version>1.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>siesta-server</artifactId>
@@ -39,8 +39,13 @@
     </dependency>
 
     <dependency>
+      <groupId>org.eclipse.sisu</groupId>
+      <artifactId>org.eclipse.sisu.inject</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.sonatype.sisu</groupId>
-      <artifactId>sisu-inject-bean</artifactId>
+      <artifactId>sisu-guice</artifactId>
     </dependency>
 
     <dependency>

--- a/siesta-server/src/main/java/org/sonatype/sisu/siesta/server/internal/ComponentDiscoveryApplication.java
+++ b/siesta-server/src/main/java/org/sonatype/sisu/siesta/server/internal/ComponentDiscoveryApplication.java
@@ -21,14 +21,14 @@ import javax.inject.Inject;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Application;
 
-import org.sonatype.guice.bean.locators.BeanLocator;
-import org.sonatype.inject.BeanEntry;
 import org.sonatype.sisu.siesta.common.Component;
 import org.sonatype.sisu.siesta.common.Resource;
 import org.sonatype.sisu.siesta.server.ApplicationSupport;
 
 import com.google.common.collect.Sets;
 import com.google.inject.Key;
+import org.eclipse.sisu.BeanEntry;
+import org.eclipse.sisu.inject.BeanLocator;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 

--- a/siesta-server/src/main/java/org/sonatype/sisu/siesta/server/internal/ResourceDiscoveryApplication.java
+++ b/siesta-server/src/main/java/org/sonatype/sisu/siesta/server/internal/ResourceDiscoveryApplication.java
@@ -20,12 +20,12 @@ import javax.inject.Inject;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Application;
 
-import org.sonatype.guice.bean.locators.BeanLocator;
-import org.sonatype.inject.BeanEntry;
 import org.sonatype.sisu.siesta.common.Resource;
 import org.sonatype.sisu.siesta.server.ApplicationSupport;
 
 import com.google.inject.Key;
+import org.eclipse.sisu.BeanEntry;
+import org.eclipse.sisu.inject.BeanLocator;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 

--- a/siesta-server/src/main/java/org/sonatype/sisu/siesta/server/internal/SiestaServlet.java
+++ b/siesta-server/src/main/java/org/sonatype/sisu/siesta/server/internal/SiestaServlet.java
@@ -24,12 +24,12 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.core.Application;
 
-import org.sonatype.guice.bean.locators.BeanLocator;
-import org.sonatype.inject.BeanEntry;
-import org.sonatype.inject.Mediator;
 import org.sonatype.sisu.siesta.server.ApplicationContainer;
 
 import com.google.inject.Key;
+import org.eclipse.sisu.BeanEntry;
+import org.eclipse.sisu.Mediator;
+import org.eclipse.sisu.inject.BeanLocator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;

--- a/siesta-server/src/main/java/org/sonatype/sisu/siesta/server/internal/jersey/SisuComponentProviderFactory.java
+++ b/siesta-server/src/main/java/org/sonatype/sisu/siesta/server/internal/jersey/SisuComponentProviderFactory.java
@@ -19,14 +19,13 @@ import java.util.Iterator;
 import javax.inject.Inject;
 import javax.inject.Named;
 
-import org.sonatype.guice.bean.locators.BeanLocator;
-import org.sonatype.inject.BeanEntry;
-
 import com.google.inject.Key;
 import com.sun.jersey.core.spi.component.ComponentContext;
 import com.sun.jersey.core.spi.component.ioc.IoCComponentProvider;
 import com.sun.jersey.core.spi.component.ioc.IoCComponentProviderFactory;
 import com.sun.jersey.core.spi.component.ioc.IoCInstantiatedComponentProvider;
+import org.eclipse.sisu.BeanEntry;
+import org.eclipse.sisu.inject.BeanLocator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/siesta-testsuite/pom.xml
+++ b/siesta-testsuite/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.sonatype.sisu.siesta</groupId>
     <artifactId>siesta</artifactId>
-    <version>1.5.3-SNAPSHOT</version>
+    <version>1.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>siesta-testsuite</artifactId>

--- a/siesta-testsuite/src/test/java/org/sonatype/sisu/siesta/testsuite/support/SiestaTestSupport.java
+++ b/siesta-testsuite/src/test/java/org/sonatype/sisu/siesta/testsuite/support/SiestaTestSupport.java
@@ -19,7 +19,6 @@ import javax.inject.Inject;
 import javax.servlet.DispatcherType;
 import javax.servlet.http.HttpServlet;
 
-import org.sonatype.inject.BeanScanning;
 import org.sonatype.sisu.litmus.testsupport.inject.InjectedTestSupport;
 
 import com.google.inject.Injector;
@@ -31,6 +30,7 @@ import com.sun.jersey.api.client.config.DefaultClientConfig;
 import com.sun.jersey.api.client.filter.LoggingFilter;
 import com.sun.jersey.api.json.JSONConfiguration;
 import org.eclipse.jetty.testing.ServletTester;
+import org.eclipse.sisu.space.BeanScanning;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;

--- a/siesta-xstream/pom.xml
+++ b/siesta-xstream/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.sonatype.sisu.siesta</groupId>
     <artifactId>siesta</artifactId>
-    <version>1.5.3-SNAPSHOT</version>
+    <version>1.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>siesta-xstream</artifactId>
@@ -30,12 +30,6 @@
     <dependency>
       <groupId>org.sonatype.sisu.siesta</groupId>
       <artifactId>siesta-common</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.sonatype.sisu</groupId>
-      <artifactId>sisu-inject-bean</artifactId>
-      <optional>true</optional>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Guice is now a provided dependency of Sisu, making it easier to swap between editions without needing exclusions.
