### PR TITLE
Add OSGi metadata

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -396,6 +396,22 @@
           </execution>
         </executions>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <!-- relax range to account for guava versioning -->
+            <_consumer-policy>$(version;==)</_consumer-policy>
+            <!-- include all content in the output directory -->
+            <Include-Resource>
+              /=${project.build.outputDirectory},{maven-resources}
+            </Include-Resource>
+          </instructions>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/siesta-api/pom.xml
+++ b/siesta-api/pom.xml
@@ -25,6 +25,7 @@
 
   <artifactId>siesta-api</artifactId>
   <name>${project.groupId}:${project.artifactId}</name>
+  <packaging>bundle</packaging>
 
   <dependencies>
     <dependency>

--- a/siesta-jackson2/pom.xml
+++ b/siesta-jackson2/pom.xml
@@ -25,6 +25,7 @@
 
   <artifactId>siesta-jackson2</artifactId>
   <name>${project.groupId}:${project.artifactId}</name>
+  <packaging>bundle</packaging>
 
   <dependencies>
     <dependency>

--- a/siesta-server/pom.xml
+++ b/siesta-server/pom.xml
@@ -25,6 +25,7 @@
 
   <artifactId>siesta-server</artifactId>
   <name>${project.groupId}:${project.artifactId}</name>
+  <packaging>bundle</packaging>
 
   <dependencies>
     <dependency>


### PR DESCRIPTION
Trivial change, but means we don't have to wrap these jars into bundles when consuming them later on.
