### PR TITLE
Expose BvalModule, ResteasyModule, and ValidationExceptionMapperSupport

### DIFF
--- a/siesta-server/src/main/java/org/sonatype/siesta/server/bval/BvalModule.java
+++ b/siesta-server/src/main/java/org/sonatype/siesta/server/bval/BvalModule.java
@@ -10,7 +10,7 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
-package org.sonatype.siesta.server.internal.bval;
+package org.sonatype.siesta.server.bval;
 
 import javax.validation.ValidationProviderResolver;
 import javax.validation.spi.BootstrapState;

--- a/siesta-server/src/main/java/org/sonatype/siesta/server/internal/validation/ConstraintViolationExceptionMapper.java
+++ b/siesta-server/src/main/java/org/sonatype/siesta/server/internal/validation/ConstraintViolationExceptionMapper.java
@@ -25,6 +25,7 @@ import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.ext.Provider;
 
 import org.sonatype.siesta.ValidationErrorXO;
+import org.sonatype.siesta.server.validation.ValidationExceptionMapperSupport;
 
 /**
  * Maps {@link ConstraintViolationException} to {@link Status#BAD_REQUEST} or {@link Status#INTERNAL_SERVER_ERROR}

--- a/siesta-server/src/main/java/org/sonatype/siesta/server/internal/validation/ValidationErrorsExceptionMapper.java
+++ b/siesta-server/src/main/java/org/sonatype/siesta/server/internal/validation/ValidationErrorsExceptionMapper.java
@@ -20,6 +20,7 @@ import javax.ws.rs.ext.Provider;
 
 import org.sonatype.siesta.ValidationErrorXO;
 import org.sonatype.siesta.ValidationErrorsException;
+import org.sonatype.siesta.server.validation.ValidationExceptionMapperSupport;
 
 /**
  * Maps {@link ValidationErrorsException} to 400 with a list of {@link ValidationErrorXO} as body.

--- a/siesta-server/src/main/java/org/sonatype/siesta/server/resteasy/ResteasyModule.java
+++ b/siesta-server/src/main/java/org/sonatype/siesta/server/resteasy/ResteasyModule.java
@@ -10,11 +10,12 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
-package org.sonatype.siesta.server.internal.resteasy;
+package org.sonatype.siesta.server.resteasy;
 
 import javax.inject.Singleton;
 
 import org.sonatype.siesta.server.ComponentContainer;
+import org.sonatype.siesta.server.internal.resteasy.ComponentContainerImpl;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;

--- a/siesta-server/src/main/java/org/sonatype/siesta/server/validation/ValidationExceptionMapperSupport.java
+++ b/siesta-server/src/main/java/org/sonatype/siesta/server/validation/ValidationExceptionMapperSupport.java
@@ -11,7 +11,7 @@
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
 
-package org.sonatype.siesta.server.internal.validation;
+package org.sonatype.siesta.server.validation;
 
 import java.util.List;
 

--- a/siesta-testsuite/src/test/java/org/sonatype/siesta/testsuite/TestModule.java
+++ b/siesta-testsuite/src/test/java/org/sonatype/siesta/testsuite/TestModule.java
@@ -13,8 +13,8 @@
 package org.sonatype.siesta.testsuite;
 
 import org.sonatype.siesta.server.SiestaServlet;
-import org.sonatype.siesta.server.internal.bval.BvalModule;
-import org.sonatype.siesta.server.internal.resteasy.ResteasyModule;
+import org.sonatype.siesta.server.bval.BvalModule;
+import org.sonatype.siesta.server.resteasy.ResteasyModule;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.AbstractModule;

--- a/siesta-webapp/src/main/java/org/sonatype/siesta/webapp/WebappModule.java
+++ b/siesta-webapp/src/main/java/org/sonatype/siesta/webapp/WebappModule.java
@@ -15,8 +15,8 @@ package org.sonatype.siesta.webapp;
 import javax.inject.Named;
 
 import org.sonatype.siesta.server.SiestaServlet;
-import org.sonatype.siesta.server.internal.bval.BvalModule;
-import org.sonatype.siesta.server.internal.resteasy.ResteasyModule;
+import org.sonatype.siesta.server.bval.BvalModule;
+import org.sonatype.siesta.server.resteasy.ResteasyModule;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.AbstractModule;


### PR DESCRIPTION
So they can be re-used in applications that deploy siesta as pure (non-embedded) bundles.
